### PR TITLE
fix(rite-of-rebirth): prevent teleport trigger after cutscene exit

### DIFF
--- a/TeleportMod.cs
+++ b/TeleportMod.cs
@@ -569,6 +569,12 @@ public class TeleportMod : BaseUnityPlugin
                 return false;
             }
 
+            if (PlayerData.instance != null && PlayerData.instance.bindCutscenePlayed == false)
+            {
+                LogInfo("Teleport blocked");
+                return false;
+            }
+
             // 检查是否正在重生
             if (GameManager.instance != null && GameManager.instance.RespawningHero)
             {


### PR DESCRIPTION
### Summary
After completing the 'wish' in the 'Rite of Rebirth' mission, the player appears trapped in roots and must press buttons to break free. Rapidly pressing multiple buttons accidentally triggered the mod's teleport right after the cutscene, causing the UI to disappear. Had to manually edit user.dat (set bindCutscenePlayed=true) to restore the UI. Teleport is now disabled in this scenario to avoid the issue.

### Steps to Reproduce
1. Complete the "wish".
2. Get trapped in roots.
3. While still trapped in the roots, active teleport — moves the player to another location.
4. UI disappears right after the cutscene ends.

### Fix
Disabled teleport during this specific cutscene exit scenario.

### Notes
Had to manually edit `user.dat` (set `bindCutscenePlayed=true`) to recover UI before this fix.
